### PR TITLE
Version bump for CDash 3.10.1

### DIFF
--- a/charts/cdash/Chart.yaml
+++ b/charts/cdash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cdash
 description: CDash aggregates, analyzes and displays the results of software testing processes
 type: application
-version: "0.2.0"
+version: "0.2.1"
 appVersion: "3.10.0"
 dependencies:
   - name: postgresql

--- a/charts/cdash/Chart.yaml
+++ b/charts/cdash/Chart.yaml
@@ -3,7 +3,7 @@ name: cdash
 description: CDash aggregates, analyzes and displays the results of software testing processes
 type: application
 version: "0.2.1"
-appVersion: "3.10.0"
+appVersion: "3.10.1"
 dependencies:
   - name: postgresql
     version: "16.3.5"

--- a/charts/cdash/templates/_helpers.tpl
+++ b/charts/cdash/templates/_helpers.tpl
@@ -21,21 +21,25 @@ Use https if `cdash.https` is true, otherwise use http.
               secretKeyRef:
                 name: "{{ .Release.Name }}-s3"
                 key: "accesskey"
+                optional: true
           - name: "AWS_BUCKET"
             valueFrom:
               secretKeyRef:
                 name: "{{ .Release.Name }}-s3"
                 key: "bucket"
+                optional: true
           - name: "AWS_REGION"
             valueFrom:
               secretKeyRef:
                 name: "{{ .Release.Name }}-s3"
                 key: "region"
+                optional: true
           - name: "AWS_SECRET_ACCESS_KEY"
             valueFrom:
               secretKeyRef:
                 name: "{{ .Release.Name }}-s3"
                 key: "secretkey"
+                optional: true
           - name: "DB_CONNECTION"
             value: "pgsql"
           - name: "DB_DATABASE"
@@ -43,21 +47,25 @@ Use https if `cdash.https` is true, otherwise use http.
               secretKeyRef:
                 name: "{{ .Release.Name }}-db"
                 key: "database"
+                optional: true
           - name: "DB_HOST"
             valueFrom:
               secretKeyRef:
                 name: "{{ .Release.Name }}-db"
                 key: "host"
+                optional: true
           - name: "DB_PORT"
             valueFrom:
               secretKeyRef:
                 name: "{{ .Release.Name }}-db"
                 key: "port"
+                optional: true
           - name: "DB_USERNAME"
             valueFrom:
               secretKeyRef:
                 name: "{{ .Release.Name }}-db"
                 key: "username"
+                optional: true
           - name: "DB_PASSWORD"
             valueFrom:
               secretKeyRef:

--- a/charts/cdash/values.yaml
+++ b/charts/cdash/values.yaml
@@ -10,7 +10,7 @@ cdash:
   https: true
 
   # cdash.image is the Docker image to use for this CDash instance.
-  image: "kitware/cdash:v3.10.0"
+  image: "kitware/cdash:v3.10.1"
 
   # This Helm chart uses an embedded postgres database by default.
   # To use an external database instead, set postgresql.enabled: false


### PR DESCRIPTION
Also mark most named environment variables as optional, so we can defer to default values without erroring.