### PR TITLE
Add release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - "release notes: ignored"
+  categories:
+    - title: "New Features"
+      labels:
+        - "release notes: features"
+    - title: "Documentation"
+      labels:
+        - "release notes: documentation"
+    - title: "Deprecations & Removals"
+      labels:
+        - "release notes: deprecated / removed"
+    - title: "Bug Fixes"
+      labels:
+        - "release notes: fixes"
+    - title: "Dependencies"
+      labels:
+        - "release notes: external dependencies"
+    - title: "Other Changes"
+      labels:
+        - "*"


### PR DESCRIPTION
Uses GitHub's [automatic](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes) release notes feature to generate categorized release notes for each release.