### PR TITLE
Remove limit on proxy body size

### DIFF
--- a/charts/cdash/Chart.yaml
+++ b/charts/cdash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cdash
 description: CDash aggregates, analyzes and displays the results of software testing processes
 type: application
-version: "0.2.1"
+version: "0.2.2"
 appVersion: "3.10.1"
 dependencies:
   - name: postgresql

--- a/charts/cdash/templates/cdash/ingress.yaml
+++ b/charts/cdash/templates/cdash/ingress.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ .Release.Name }}-website
   labels:
     app: {{ .Release.Name }}-website
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+
 spec:
   ingressClassName: nginx
   {{ if .Values.cdash.https }}


### PR DESCRIPTION
This annotation fixes the following problem when submitting large files to CDash.

413 Request Entity Too Large