### PR TITLE
Define APP_URL for worker pods

### DIFF
--- a/charts/cdash/Chart.yaml
+++ b/charts/cdash/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cdash
 description: CDash aggregates, analyzes and displays the results of software testing processes
 type: application
-version: "0.5.0"
+version: "0.6.0"
 appVersion: "4.2.0"
 dependencies:
   - name: postgresql

--- a/charts/cdash/templates/_helpers.tpl
+++ b/charts/cdash/templates/_helpers.tpl
@@ -16,6 +16,8 @@ Use https if `cdash.https` is true, otherwise use http.
               secretKeyRef:
                 name: "{{ .Release.Name }}-website"
                 key: "APP_KEY"
+          - name: "APP_URL"
+            value: {{ template "cdash.url" . }}
           - name: "AWS_ACCESS_KEY_ID"
             valueFrom:
               secretKeyRef:

--- a/charts/cdash/templates/cdash/deployment.yaml
+++ b/charts/cdash/templates/cdash/deployment.yaml
@@ -25,6 +25,4 @@ spec:
           command: [ "/bin/bash", "/cdash/docker/docker-entrypoint.sh" ]
           args: [ "start-website" ]
           env:
-          - name: "APP_URL"
-            value: {{ template "cdash.url" . }}
           {{ template "cdash.environment" . }}


### PR DESCRIPTION
This resolves an issue we noticed where email notifications would contain incorrect URLs to CDash results.